### PR TITLE
修复任务状态按钮不能正确更新实际开始/结束时间的bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -1302,13 +1302,28 @@ async function setTaskStatus(projectId, taskId, status) {
                 break;
                 
             case 'in-progress':
-                // 设置实际开始时间，清除结束时间
+                // 获取当前任务数据，只在没有开始时间时设置
+                const { data: taskInProgress, error: fetchInProgressError } = await supabaseClient
+                    .from('tasks')
+                    .select('actual_start_date')
+                    .eq('id', taskId)
+                    .single();
+                
+                if (fetchInProgressError) {
+                    console.error('Error fetching task:', fetchInProgressError);
+                    return;
+                }
+                
+                // 只有当任务还没有实际开始时间时，才设置它（避免覆盖原始开始时间）
                 updateData = {
-                    actual_start_date: now,
                     actual_end_date: null,
                     actual_duration: null,
                     completed: false
                 };
+                
+                if (!taskInProgress.actual_start_date) {
+                    updateData.actual_start_date = now;
+                }
                 break;
                 
             case 'done':
@@ -1324,21 +1339,25 @@ async function setTaskStatus(projectId, taskId, status) {
                     return;
                 }
                 
+                // 如果任务没有开始时间，设置开始时间为当前时间
+                const actualStartDate = task.actual_start_date || now;
+                
                 // 计算实际耗时（小时）
                 let actualDuration = null;
-                if (task.actual_start_date) {
-                    const startTime = new Date(task.actual_start_date);
-                    const endTime = new Date(now);
-                    actualDuration = (endTime - startTime) / (1000 * 60 * 60);
-                    actualDuration = Math.round(actualDuration * 100) / 100;
-                }
+                const startTime = new Date(actualStartDate);
+                const endTime = new Date(now);
+                actualDuration = (endTime - startTime) / (1000 * 60 * 60);
+                actualDuration = Math.round(actualDuration * 100) / 100;
                 
                 updateData = {
                     actual_end_date: now,
-                    completed: true
+                    completed: true,
+                    actual_duration: actualDuration
                 };
-                if (actualDuration !== null) {
-                    updateData.actual_duration = actualDuration;
+                
+                // 如果之前没有开始时间，现在设置它
+                if (!task.actual_start_date) {
+                    updateData.actual_start_date = now;
                 }
                 break;
         }


### PR DESCRIPTION
## 问题描述

修复 #13 - 任务状态按钮不能正确更新实际开始时间和实际结束时间

## 修复内容

### in-progress 状态
- 先查询任务当前的 \ctual_start_date\
- 只有当任务还没有实际开始时间时，才设置新的开始时间
- **避免了反复点击 in-progress 按钮导致开始时间被覆盖的问题**

### done 状态
- 如果任务没有 \ctual_start_date\，会自动设置为完成时的时间
- 确保每个完成的任务都有开始时间和结束时间
- 正确计算实际耗时（\ctual_duration\）

## 测试建议

1. 创建一个新任务
2. 点击 in-progress 按钮，记录开始时间
3. 再次点击 in-progress 按钮，确认开始时间没有变化
4. 点击 done 按钮，确认结束时间已设置
5. 验证实际耗时计算正确

Fixes #13