### PR TITLE
feat: AI任务补全优化与样式Token化重构

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="ARTEMIS - 极简项目管理系统">
     <title>ARTEMIS</title>
-    <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
     <div id="root"></div>

--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -21,7 +21,7 @@ import { TimeFieldGroup } from './TimeFieldGroup';
 import { PriorityMatrixPicker } from './PriorityMatrixPicker';
 import { PrerequisitePicker } from './PrerequisitePicker';
 import { BountyPicker } from './BountyPicker';
-import type { Task, TaskPriority } from '../types';
+import type { Project, Task, TaskPriority } from '../types';
 
 // ============================================================
 // 类型
@@ -134,6 +134,31 @@ function fmtPriority(imp: number, urg: number): string {
   return `${iLabel} / ${uLabel}`;
 }
 
+function buildProjectContext(project: Project | undefined): string {
+  if (!project) return '';
+
+  const segments: string[] = [];
+  segments.push(`项目名：${project.name}`);
+
+  if (project.category) {
+    segments.push(`类别：${project.category}`);
+  }
+
+  if (project.priority) {
+    segments.push(`项目优先级：${project.priority}`);
+  }
+
+  if (project.plan_duration !== null) {
+    segments.push(`预计总耗时：${project.plan_duration}小时`);
+  }
+
+  if (project.bounty !== null) {
+    segments.push(`项目赏金：${project.bounty}`);
+  }
+
+  return segments.join('；');
+}
+
 // ============================================================
 // 组件
 // ============================================================
@@ -159,6 +184,7 @@ export const TaskEditModal = memo(function TaskEditModal({
   const [showBounty, setShowBounty] = useState(false);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiError, setAiError] = useState('');
+  const [aiPreviousDescription, setAiPreviousDescription] = useState<string | null>(null);
 
   // 初始化表单（仅首次 / taskId 变化时）
   useEffect(() => {
@@ -337,11 +363,18 @@ export const TaskEditModal = memo(function TaskEditModal({
       return;
     }
 
+    const projectContext = buildProjectContext(project);
+
     setAiError('');
     setAiLoading(true);
     try {
-      const result = await suggestTaskDescriptionByTitle(title);
+      const result = await suggestTaskDescriptionByTitle({
+        taskTitle: title,
+        projectContext,
+        draftDescription: form.description,
+      });
       setForm((prev) => {
+        setAiPreviousDescription(prev.description);
         const next = { ...prev, description: result.description };
         autoSave(next);
         return next;
@@ -352,7 +385,18 @@ export const TaskEditModal = memo(function TaskEditModal({
     } finally {
       setAiLoading(false);
     }
-  }, [form.name, autoSave]);
+  }, [form.name, form.description, project, autoSave]);
+
+  const handleUndoAiFill = useCallback(() => {
+    if (aiPreviousDescription === null) return;
+    setForm((prev) => {
+      const next = { ...prev, description: aiPreviousDescription };
+      autoSave(next);
+      return next;
+    });
+    setAiPreviousDescription(null);
+    setAiError('');
+  }, [aiPreviousDescription, autoSave]);
 
   return (
     <div className="modal-overlay" style={{ display: 'flex' }} onClick={onClose}>
@@ -456,18 +500,30 @@ export const TaskEditModal = memo(function TaskEditModal({
 
             {/* 详情 - 跨三列 */}
             <div className="form-item form-item-full">
-              <label style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px' }}>
-                <span>详情</span>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  style={{ padding: '4px 8px', fontSize: '12px' }}
-                  onClick={handleAiFillDescription}
-                  disabled={aiLoading}
-                >
-                  {aiLoading ? 'AI 生成中...' : 'AI补全'}
-                </button>
-              </label>
+              <div className="form-item-header">
+                <label>详情</label>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  {aiPreviousDescription !== null && (
+                    <button
+                      type="button"
+                      className="btn-secondary"
+                      style={{ padding: '4px 8px', fontSize: '12px' }}
+                      onClick={handleUndoAiFill}
+                    >
+                      撤销AI
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    style={{ padding: '4px 8px', fontSize: '12px' }}
+                    onClick={handleAiFillDescription}
+                    disabled={aiLoading}
+                  >
+                    {aiLoading ? 'AI 生成中...' : 'AI补全'}
+                  </button>
+                </div>
+              </div>
               <textarea
                 value={form.description}
                 onChange={(e) => handleChange('description', e.target.value)}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -37,7 +37,7 @@ const TaskStatusBar = memo(function TaskStatusBar({ currentStatus, onChangeStatu
       {STATUS_OPTIONS.map(({ key, label }) => (
         <button
           key={key}
-          className={`task-status-btn ${key === 'in-progress' ? 'status-progress' : ''} ${
+          className={`task-status-btn status-${key} ${
             currentStatus === key ? 'active' : ''
           }`}
           onClick={(e) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,14 +12,31 @@ export interface AiTaskDescriptionSuggestion {
   description: string;
 }
 
-export async function suggestTaskDescriptionByTitle(taskTitle: string): Promise<AiTaskDescriptionSuggestion> {
+interface SuggestTaskDescriptionInput {
+  taskTitle: string;
+  projectContext?: string;
+  draftDescription?: string;
+}
+
+export async function suggestTaskDescriptionByTitle({
+  taskTitle,
+  projectContext,
+  draftDescription,
+}: SuggestTaskDescriptionInput): Promise<AiTaskDescriptionSuggestion> {
   const trimmedTitle = taskTitle.trim();
   if (!trimmedTitle) {
     throw new Error('任务标题不能为空');
   }
 
+  const trimmedContext = projectContext?.trim();
+  const trimmedDraft = draftDescription?.trim();
+
   const { data, error } = await supabase.functions.invoke('ai-task-suggest', {
-    body: { taskTitle: trimmedTitle },
+    body: {
+      taskTitle: trimmedTitle,
+      projectContext: trimmedContext ? trimmedContext.slice(0, 240) : undefined,
+      draftDescription: trimmedDraft ? trimmedDraft.slice(0, 300) : undefined,
+    },
   });
 
   if (error) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './components';
+import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -56,6 +56,19 @@
     --color-hover-danger: #ff0000;   /* 危险悬停 - 纯红 */
     --color-on-primary: #000000;     /* 主色调上的文字 - 黑色 */
 
+    /* ========== 主题色板层（Palette Tokens）========== */
+    --palette-neutral-500: var(--color-secondary);
+    --palette-info-500: var(--color-cyan);
+    --palette-warning-500: var(--color-warning);
+    --palette-success-500: var(--color-success);
+
+    /* ========== 状态语义层（Semantic Tokens）========== */
+    --status-backlog-bg: var(--palette-neutral-500);
+    --status-ready-bg: var(--palette-info-500);
+    --status-inprogress-bg: var(--palette-warning-500);
+    --status-done-bg: var(--palette-success-500);
+    --status-chip-text-on: var(--color-on-primary);
+
     /* ========== 背景色 ========== */
     --bg-page: #000000;              /* 页面背景 */
     --bg-card: #000000;              /* 卡片背景 */
@@ -131,6 +144,18 @@ body.theme-hp37000 {
     --border-outer: #fea500;
     --border-module: #fea500;
     --border-light: #66ffcc;
+
+    /* 状态色板（示例：该主题下可独立覆盖） */
+    --palette-neutral-500: #5e5e5e;
+    --palette-info-500: #3f85ff;
+    --palette-warning-500: #ffcc00;
+    --palette-success-500: #2fc276;
+
+    --status-backlog-bg: var(--palette-neutral-500);
+    --status-ready-bg: var(--palette-info-500);
+    --status-inprogress-bg: var(--palette-warning-500);
+    --status-done-bg: var(--palette-success-500);
+    --status-chip-text-on: #000000;
 
     --shadow-card: none;
     --shadow-modal: 0 0 20px rgba(255, 204, 0, 0.3);
@@ -802,10 +827,28 @@ button:hover {
     border-color: var(--text-primary);
 }
 
-.task-status-btn.status-progress.active {
-    background: var(--color-warning);
-    color: var(--text-on-module);
-    border-color: var(--color-warning);
+.task-status-btn.status-backlog.active {
+    background: var(--status-backlog-bg);
+    color: var(--status-chip-text-on);
+    border-color: var(--status-backlog-bg);
+}
+
+.task-status-btn.status-ready.active {
+    background: var(--status-ready-bg);
+    color: var(--status-chip-text-on);
+    border-color: var(--status-ready-bg);
+}
+
+.task-status-btn.status-in-progress.active {
+    background: var(--status-inprogress-bg);
+    color: var(--status-chip-text-on);
+    border-color: var(--status-inprogress-bg);
+}
+
+.task-status-btn.status-done.active {
+    background: var(--status-done-bg);
+    color: var(--status-chip-text-on);
+    border-color: var(--status-done-bg);
 }
 
 /* 任务名称 - 黑色文字 */
@@ -979,6 +1022,13 @@ button:hover {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xs);
+}
+
+.form-item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
 }
 
 /* 全宽表单项（如详情输入框） */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,3 @@
+@import './base.css';
+@import './tokens.css';
+@import './theme-status-overrides.css';

--- a/src/styles/theme-status-overrides.css
+++ b/src/styles/theme-status-overrides.css
@@ -1,0 +1,142 @@
+body.theme-hp37000 {
+  --palette-neutral-500: #5e5e5e;
+  --palette-info-500: #3f85ff;
+  --palette-warning-500: #ffcc00;
+  --palette-success-500: #2fc276;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #000000;
+}
+
+body.theme-hp9845 {
+  --palette-neutral-500: #6d5a46;
+  --palette-info-500: #1f4db8;
+  --palette-warning-500: #ff8a00;
+  --palette-success-500: #0f7a64;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #ffffff;
+}
+
+body.theme-hp54600-new {
+  --palette-neutral-500: #2b5f2b;
+  --palette-info-500: #73f073;
+  --palette-warning-500: #c8ff6d;
+  --palette-success-500: #60ff57;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #001600;
+}
+
+body.theme-hp54600-aged {
+  --palette-neutral-500: #4d6d50;
+  --palette-info-500: #86d38a;
+  --palette-warning-500: #b9d18f;
+  --palette-success-500: #7fbe7a;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #102010;
+}
+
+body.theme-paris {
+  --palette-neutral-500: #8e1d2e;
+  --palette-info-500: #ffd7d7;
+  --palette-warning-500: #ffffff;
+  --palette-success-500: #ff7f93;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #b50018;
+}
+
+body.theme-iknowiletudown {
+  --palette-neutral-500: #6f482d;
+  --palette-info-500: #ff9f33;
+  --palette-warning-500: #f08a00;
+  --palette-success-500: #e07c00;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #111111;
+}
+
+body.theme-dynamicron-e180 {
+  --palette-neutral-500: #2f3f78;
+  --palette-info-500: #ef513c;
+  --palette-warning-500: #f2b126;
+  --palette-success-500: #f0941f;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #121a3b;
+}
+
+body.theme-vhs-future-1976 {
+  --palette-neutral-500: #6c6c6c;
+  --palette-info-500: #2f3152;
+  --palette-warning-500: #ef7d24;
+  --palette-success-500: #f2b12d;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #f5f2df;
+}
+
+body.theme-vhs-pixel-sunset {
+  --palette-neutral-500: #5a5f70;
+  --palette-info-500: #2a4f92;
+  --palette-warning-500: #ef8f33;
+  --palette-success-500: #f2d546;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #ffffff;
+}
+
+body.theme-basf-sm90 {
+  --palette-neutral-500: #505050;
+  --palette-info-500: #1d1d1d;
+  --palette-warning-500: #ff8a3d;
+  --palette-success-500: #e8602d;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #f7f7f7;
+}
+
+body.theme-vhs-t120-light {
+  --palette-neutral-500: #6a2a56;
+  --palette-info-500: #ca244a;
+  --palette-warning-500: #ff5b2a;
+  --palette-success-500: #f2c83d;
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: #ffffff;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,12 @@
+:root {
+  --palette-neutral-500: var(--color-secondary);
+  --palette-info-500: var(--color-cyan);
+  --palette-warning-500: var(--color-warning);
+  --palette-success-500: var(--color-success);
+
+  --status-backlog-bg: var(--palette-neutral-500);
+  --status-ready-bg: var(--palette-info-500);
+  --status-inprogress-bg: var(--palette-warning-500);
+  --status-done-bg: var(--palette-success-500);
+  --status-chip-text-on: var(--color-on-primary);
+}

--- a/supabase/functions/ai-task-suggest/index.ts
+++ b/supabase/functions/ai-task-suggest/index.ts
@@ -23,7 +23,7 @@ serve(async (req) => {
   }
 
   try {
-    const { taskTitle } = await req.json();
+    const { taskTitle, projectContext, draftDescription } = await req.json();
 
     if (typeof taskTitle !== 'string' || !taskTitle.trim()) {
       return new Response(JSON.stringify({ error: 'taskTitle is required' }), {
@@ -42,8 +42,20 @@ serve(async (req) => {
 
     const model = Deno.env.get('QWEN_MODEL') || 'qwen-turbo';
 
-    const systemPrompt = '你是项目管理助手。仅输出一句中文任务描述，不超过32个字，不要加引号。';
-    const userPrompt = `任务标题：${taskTitle.trim()}\n请给出一句可执行的任务描述。`;
+    const systemPrompt = [
+      '你是项目管理助手，负责把用户的任务草稿梳理、理顺和润色。',
+      '要求：输出1-3句中文，60-160字，不要加引号。',
+      '优先保留用户原文中的关键信息（名词、数字、约束、已有结论），不要凭空编造。',
+      '在不改变原意前提下，补充更清晰的执行动作或产出物。',
+      '避免空泛套话，语言简洁、自然、可执行。',
+    ].join(' ');
+    const contextLine = typeof projectContext === 'string' && projectContext.trim()
+      ? `项目上下文：${projectContext.trim().slice(0, 240)}\n`
+      : '';
+    const draftLine = typeof draftDescription === 'string' && draftDescription.trim()
+      ? `已有草稿：${draftDescription.trim().slice(0, 300)}\n请在其基础上补全优化。\n`
+      : '';
+    const userPrompt = `${contextLine}${draftLine}任务标题：${taskTitle.trim()}\n请基于已有信息做梳理和润色，让描述更清晰可执行。`;
 
     const aiResp = await fetch('https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions', {
       method: 'POST',
@@ -57,8 +69,8 @@ serve(async (req) => {
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt },
         ],
-        temperature: 0.2,
-        max_tokens: 64,
+        temperature: 0.1,
+        max_tokens: 140,
       }),
     });
 
@@ -72,7 +84,7 @@ serve(async (req) => {
 
     const data = await aiResp.json() as DashScopeResponse;
     const raw = data.choices?.[0]?.message?.content?.trim() ?? '';
-    const description = raw.replace(/[\r\n]+/g, ' ').slice(0, 120).trim();
+    const description = raw.replace(/[\r\n]+/g, ' ').slice(0, 280).trim();
 
     if (!description) {
       return new Response(JSON.stringify({ error: 'Empty model output' }), {


### PR DESCRIPTION
## 变更内容
- AI 补全支持输入任务标题 + 项目上下文 + 当前详情草稿
- 新增 撤销AI，可一键回退到补全前内容
- 优化 AI 提示词为通用梳理润色模式，减少空泛输出
- 任务状态按钮改为分层 token（状态类 -> 语义变量 -> 主题色板）
- 样式从根目录迁移至 src/styles，拆分为 base.css / tokens.css / theme-status-overrides.css

## 验证
- npm run build 通过
- Supabase Edge Function ai-task-suggest 已联通（POST 200）

Closes #11